### PR TITLE
feat: add axis_from_cylindric_faces and cylindric_faces

### DIFF
--- a/build123d_ease/__init__.py
+++ b/build123d_ease/__init__.py
@@ -2,9 +2,11 @@
 
 from . import align, fetch_faces, rotation
 from .ci_show import show
+from .fetch_axes import axis_from_cylindric_faces
 from .fetch_faces import (
     back_face_of,
     bottom_face_of,
+    cylindric_faces,
     front_face_of,
     left_face_of,
     right_face_of,
@@ -26,4 +28,6 @@ __all__ = [
     "rotation",
     "show",
     "top_face_of",
+    "cylindric_faces",
+    "axis_from_cylindric_faces",
 ]

--- a/build123d_ease/fetch_axes.py
+++ b/build123d_ease/fetch_axes.py
@@ -4,7 +4,7 @@ import build123d as bd
 
 
 def axis_from_cylindric_faces(face: bd.Face) -> bd.Axis:
-    """Return a the central axis for a cylindrical face.
+    """Return the central axis for a cylindrical face.
 
     Returns:
         bd.Axis: The central axis through the cyindrical face.

--- a/build123d_ease/fetch_axes.py
+++ b/build123d_ease/fetch_axes.py
@@ -1,0 +1,19 @@
+"""Fetch axes from a build123d Face objects."""
+
+import build123d as bd
+
+
+def axis_from_cylindric_faces(face: bd.Face) -> bd.Axis:
+    """Return a the central axis for a cylindrical face.
+
+    Returns:
+        bd.Axis: The central axis through the cyindrical face.
+
+    """
+    position = 0.5 * (face.position_at(0, 0.5) + face.position_at(0.5, 0.5))
+    direction = next(
+        edge.location_at(1).to_axis().direction
+        for edge in face.edges()
+        if not edge.is_closed
+    )
+    return bd.Axis(position, direction)

--- a/tests/test_fetch_axes.py
+++ b/tests/test_fetch_axes.py
@@ -1,0 +1,18 @@
+"""Tests for the `fetch axes` module."""
+
+import build123d as bd
+
+import build123d_ease as bde
+
+
+def test_axis_from_cylindric_faces() -> None:
+    """Validates if an axis for a simple cylinder could be found."""
+    p = bd.Part(None) + bd.Cylinder(
+        radius=10,
+        height=10,
+    )
+    face = p.faces().filter_by(bd.GeomType.CYLINDER)[0]
+    calculated_axis = bde.axis_from_cylindric_faces(face)
+    expected_axis = bd.Axis((0, 0, 0), (0, 0, 1))
+
+    assert expected_axis == calculated_axis

--- a/tests/test_fetch_faces.py
+++ b/tests/test_fetch_faces.py
@@ -1,0 +1,65 @@
+"""Tests for the `fetch faces` module."""
+
+from math import isclose, pi
+
+import build123d as bd
+
+import build123d_ease as bde
+
+
+def test_cylindric_faces_find_hole() -> None:
+    """Validate finding a cylindric face for a hole."""
+    r = 10
+    h = 10
+    p = (
+        bd.Part(None)
+        + bd.Box(length=30, width=30, height=30)
+        - bd.Cylinder(
+            radius=r,
+            height=h,
+            align=bde.align.ANCHOR_TOP,
+        )
+    )
+    cylindric_face: bd.Face = bde.cylindric_faces(p, cylinder_type="hole")[0]
+    expected_face_area = 2 * pi * r * h
+    assert isclose(cylindric_face.area, expected_face_area, rel_tol=1e-6)
+
+
+def test_cylindric_faces_find_pin() -> None:
+    """Validate finding a cylindric face for a pin."""
+    r = 10
+    h = 10
+    p = (
+        bd.Part(None)
+        + bd.Box(length=30, width=60, height=30, align=bde.align.ANCHOR_BOTTOM)
+        + bd.Cylinder(
+            radius=r,
+            height=h,
+            align=bde.align.ANCHOR_TOP,
+        )
+    )
+    cylindric_face = bde.cylindric_faces(p, cylinder_type="pin")[0]
+    expected_face_area = 2 * pi * r * h
+    assert isclose(cylindric_face.area, expected_face_area, rel_tol=1e-6)
+
+
+def test_cylindric_faces_find_all() -> None:
+    """Validate finding cylindric faces, one hole and one pin."""
+    r = 10
+    h = 10
+    p = (
+        bd.Part(None)
+        + bd.Box(length=30, width=60, height=30, align=bde.align.ANCHOR_BOTTOM)
+        + bd.Cylinder(
+            radius=r,
+            height=h,
+            align=bde.align.ANCHOR_TOP,
+        )
+        - bd.Cylinder(radius=0.5 * r, height=h, align=bde.align.ANCHOR_TOP)
+    )
+    cylindric_faces = bde.cylindric_faces(p)
+    expected_face_area_pin = 2 * pi * r * h
+    expected_face_area_hole = 2 * pi * 0.5 * r * h
+
+    assert isclose(cylindric_faces[0].area, expected_face_area_pin, rel_tol=1e-6)
+    assert isclose(cylindric_faces[1].area, expected_face_area_hole, rel_tol=1e-6)


### PR DESCRIPTION
This is a useful feature when you want to construct revolutejoint mates, without defining the joint locations at part level.

This topic was asked by the user miripirie:
https://discord.com/channels/964330484911972403/1074840524181217452/1323401533383250061